### PR TITLE
Win32: Allow building MSVC 2012 (VC11)

### DIFF
--- a/config.h.win32
+++ b/config.h.win32
@@ -92,3 +92,26 @@
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
+
+/* Define to 1 if you have the declaration of `INFINITY', and to 0 if you
+   don't. */
+#undef HAVE_DECL_INFINITY
+
+/* Define to 1 if you have the declaration of `isinf', and to 0 if you don't.
+   */
+#undef HAVE_DECL_ISINF
+
+/* Define to 1 if you have the declaration of `_finite', and to 0 if you don't.
+   */
+#define HAVE_DECL__FINITE
+
+/* Define to 1 if you have the declaration of `isnan', and to 0 if you don't.
+   */
+#undef HAVE_DECL_ISNAN
+
+/* Define to 1 if you have the declaration of `_isnan', and to 0 if you don't.
+   */
+#define HAVE_DECL__ISNAN
+
+/* Define to 1 if you have the declaration of `nan', and to 0 if you don't. */
+#undef HAVE_DECL_NAN

--- a/json-c.sln
+++ b/json-c.sln
@@ -1,0 +1,19 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "json-c", "json-c.vcxproj", "{7C7DD6A6-A52A-432B-A6BB-629DAAE738ED}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7C7DD6A6-A52A-432B-A6BB-629DAAE738ED}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7C7DD6A6-A52A-432B-A6BB-629DAAE738ED}.Debug|Win32.Build.0 = Debug|Win32
+		{7C7DD6A6-A52A-432B-A6BB-629DAAE738ED}.Release|Win32.ActiveCfg = Release|Win32
+		{7C7DD6A6-A52A-432B-A6BB-629DAAE738ED}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/json-c.vcxproj
+++ b/json-c.vcxproj
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7C7DD6A6-A52A-432B-A6BB-629DAAE738ED}</ProjectGuid>
+    <RootNamespace>jsonc</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v110</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v110</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <CustomBuildBeforeTargets>
+    </CustomBuildBeforeTargets>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalOptions>/DWIN32 /D_CRT_SECURE_NO_WARNINGS  /D_CRT_NONSTDC_NO_DEPRECATE %(AdditionalOptions)</AdditionalOptions>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <CustomBuildStep>
+      <Command>
+      </Command>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Message>
+      </Message>
+    </CustomBuildStep>
+    <PreBuildEvent>
+      <Command>copy config.h.win32 config.h &amp; copy json_config.h.win32 json_config.h</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>copy config.h from Windows template instead of calling configure</Message>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="arraylist.h" />
+    <ClInclude Include="bits.h" />
+    <ClInclude Include="debug.h" />
+    <ClInclude Include="json.h" />
+    <ClInclude Include="json_c_version.h" />
+    <ClInclude Include="json_inttypes.h" />
+    <ClInclude Include="json_object.h" />
+    <ClInclude Include="json_object_iterator.h" />
+    <ClInclude Include="json_object_private.h" />
+    <ClInclude Include="json_tokener.h" />
+    <ClInclude Include="json_util.h" />
+    <ClInclude Include="linkhash.h" />
+    <ClInclude Include="math_compat.h" />
+    <ClInclude Include="printbuf.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="arraylist.c" />
+    <ClCompile Include="debug.c" />
+    <ClCompile Include="json_c_version.c" />
+    <ClCompile Include="json_object.c" />
+    <ClCompile Include="json_object_iterator.c" />
+    <ClCompile Include="json_tokener.c" />
+    <ClCompile Include="json_util.c" />
+    <ClCompile Include="libjson.c" />
+    <ClCompile Include="linkhash.c" />
+    <ClCompile Include="printbuf.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/json_config.h.win32
+++ b/json_config.h.win32
@@ -1,0 +1,2 @@
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef JSON_C_HAVE_INTTYPES_H

--- a/json_inttypes.h
+++ b/json_inttypes.h
@@ -6,13 +6,22 @@
 
 #if defined(_MSC_VER) && _MSC_VER <= 1700
 
+#if defined(_MSC_VER) && _MSC_VER >= 1600
+#include <stdint.h>
+#endif
+
 /* Anything less than Visual Studio C++ 10 is missing stdint.h and inttypes.h */
 typedef __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+#if (!defined(__cplusplus))
 #define INT32_MIN    ((int32_t)_I32_MIN)
 #define INT32_MAX    ((int32_t)_I32_MAX)
+#endif
 typedef __int64 int64_t;
+#if (!defined(__cplusplus))
 #define INT64_MIN    ((int64_t)_I64_MIN)
 #define INT64_MAX    ((int64_t)_I64_MAX)
+#endif
 #define PRId64 "I64d"
 #define SCNd64 "I64d"
 

--- a/json_object.c
+++ b/json_object.c
@@ -390,7 +390,7 @@ void json_object_object_add(struct json_object* jso, const char *key,
 		lh_table_insert(jso->o.c_object, strdup(key), val);
 		return;
 	}
-	existing_value = (void *)existing_entry->v;
+	existing_value = (json_object *)existing_entry->v;
 	if (existing_value)
 		json_object_put(existing_value);
 	existing_entry->v = val;
@@ -625,8 +625,8 @@ struct json_object* json_object_new_double_s(double d, const char *ds)
 int json_object_userdata_to_json_string(struct json_object *jso,
 	struct printbuf *pb, int level, int flags)
 {
-	int userdata_len = strlen(jso->_userdata);
-	printbuf_memappend(pb, jso->_userdata, userdata_len);
+	int userdata_len = strlen((const char *)jso->_userdata);
+	printbuf_memappend(pb, (const char *)jso->_userdata, userdata_len);
 	return userdata_len;
 }
 

--- a/json_tokener.c
+++ b/json_tokener.c
@@ -16,6 +16,7 @@
 #include "config.h"
 
 #include <math.h>
+#include "math_compat.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>

--- a/linkhash.c
+++ b/linkhash.c
@@ -17,7 +17,17 @@
 #include <stddef.h>
 #include <limits.h>
 
+#ifdef HAVE_ENDIAN_H
+# include <endian.h>    /* attempt to define endianness */
+#endif
+
 #include "linkhash.h"
+#include "json_inttypes.h"
+
+#ifdef _MSC_VER
+#define WIN32_MEAN_AND_LEAN
+#include <Windows.h>
+#endif
 
 void lh_abort(const char *msg, ...)
 {

--- a/math_compat.h
+++ b/math_compat.h
@@ -17,12 +17,25 @@
 # endif
 #endif
 
+#ifdef WIN32
+#ifndef NAN
+const unsigned long __json_nan[2] = {0xffffffff, 0x7fffffff};
+#define NAN (*(const double*) __json_nan)
+#endif
+#else
 #ifndef HAVE_DECL_NAN
 #error This platform does not have nan()
 #endif
+#endif
 
+#ifdef WIN32
+#include <float.h>
+#ifndef INFINITY
+#define INFINITY DBL_MAX
+#endif
+#else
 #ifndef HAVE_DECL_INFINITY
 #error This platform does not have INFINITY
 #endif
-
+#endif
 #endif


### PR DESCRIPTION
Since I did not want to use cygwin to build the Zephir Parser,
I backported some win32 patches.


I atleast was able to build lemon and the zephir parser
under win32 without cygwin libraries :)